### PR TITLE
Implement minimal Instagram scheduler UI

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,13 +1,103 @@
 """Main application window."""
-from PySide6 import QtWidgets
+from datetime import datetime
+from pathlib import Path
+
+from PySide6 import QtCore, QtWidgets
+
+from backend.models import Video
+from backend.instagram import post_to_instagram
+from .schedule_dialog import ScheduleDialog
 
 
 class MainWindow(QtWidgets.QMainWindow):
+    """Very small GUI showcasing the core workflow."""
+
     def __init__(self, session, scheduler, parent=None):
         super().__init__(parent)
         self.session = session
         self.scheduler = scheduler
+
         self.setWindowTitle("Instagram Scheduler")
-        label = QtWidgets.QLabel("Instagram Scheduler", self)
-        label.setAlignment(QtWidgets.Qt.AlignCenter)
-        self.setCentralWidget(label)
+        self.resize(800, 600)
+
+        central = QtWidgets.QWidget(self)
+        self.setCentralWidget(central)
+        layout = QtWidgets.QVBoxLayout(central)
+
+        self.tree = QtWidgets.QTreeWidget()
+        self.tree.setHeaderLabels(["Title", "Status", "Scheduled", "Posted"])
+        layout.addWidget(self.tree)
+
+        btn_layout = QtWidgets.QHBoxLayout()
+        self.btn_refresh = QtWidgets.QPushButton("Refresh")
+        self.btn_schedule = QtWidgets.QPushButton("Schedule")
+        self.btn_post_now = QtWidgets.QPushButton("Post Now")
+        btn_layout.addWidget(self.btn_refresh)
+        btn_layout.addWidget(self.btn_schedule)
+        btn_layout.addWidget(self.btn_post_now)
+        layout.addLayout(btn_layout)
+
+        self.btn_refresh.clicked.connect(self.load_videos)
+        self.btn_schedule.clicked.connect(self.schedule_selected)
+        self.btn_post_now.clicked.connect(self.post_selected)
+
+        self.load_videos()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def load_videos(self) -> None:
+        """Populate the tree widget with current videos."""
+        self.tree.clear()
+        videos = self.session.query(Video).filter_by(is_active=True).all()
+        for video in videos:
+            status = (
+                "Posted"
+                if video.posted_at
+                else ("Scheduled" if video.scheduled_at else "Unscheduled")
+            )
+            item = QtWidgets.QTreeWidgetItem(
+                [
+                    video.title or Path(video.file_path).name,
+                    status,
+                    str(video.scheduled_at) if video.scheduled_at else "",
+                    str(video.posted_at) if video.posted_at else "",
+                ]
+            )
+            item.setData(0, QtCore.Qt.UserRole, video.id)
+            self.tree.addTopLevelItem(item)
+
+    def _current_video(self) -> Video | None:
+        item = self.tree.currentItem()
+        if not item:
+            return None
+        vid_id = item.data(0, QtCore.Qt.UserRole)
+        return self.session.get(Video, vid_id)
+
+    # ------------------------------------------------------------------
+    # Slots
+    # ------------------------------------------------------------------
+    def schedule_selected(self) -> None:
+        video = self._current_video()
+        if not video:
+            return
+        dlg = ScheduleDialog(video.scheduled_at, self)
+        if dlg.exec():
+            video.scheduled_at = dlg.scheduled_at
+            self.session.commit()
+            self.load_videos()
+
+    def post_selected(self) -> None:
+        video = self._current_video()
+        if not video:
+            return
+        try:
+            post_to_instagram(self.session, video)
+            video.posted_at = datetime.utcnow()
+            self.session.commit()
+        except Exception as exc:  # pragma: no cover - network errors
+            video.last_error = str(exc)
+            self.session.commit()
+            QtWidgets.QMessageBox.warning(self, "Error", str(exc))
+        self.load_videos()
+

--- a/gui/schedule_dialog.py
+++ b/gui/schedule_dialog.py
@@ -1,14 +1,34 @@
-"""Dialog for per-day schedule templates."""
-from PySide6 import QtWidgets
+"""Dialog for setting a video's scheduled time."""
+from datetime import datetime
+
+from PySide6 import QtCore, QtWidgets
 
 
 class ScheduleDialog(QtWidgets.QDialog):
-    def __init__(self, parent=None):
+    """Simple datetime picker dialog."""
+
+    def __init__(self, scheduled_at: datetime | None, parent=None):
         super().__init__(parent)
-        self.setWindowTitle("Schedule Grid")
+        self.setWindowTitle("Schedule Video")
+
         layout = QtWidgets.QVBoxLayout(self)
-        layout.addWidget(QtWidgets.QLabel("Schedule grid goes here"))
-        buttons = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel)
+
+        self.dt = QtWidgets.QDateTimeEdit(self)
+        self.dt.setCalendarPopup(True)
+        if scheduled_at:
+            self.dt.setDateTime(QtCore.QDateTime.fromPython(scheduled_at))
+        else:
+            self.dt.setDateTime(QtCore.QDateTime.currentDateTime())
+        layout.addWidget(self.dt)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel,
+            parent=self,
+        )
         layout.addWidget(buttons)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
+
+    @property
+    def scheduled_at(self) -> datetime:
+        return self.dt.dateTime().toPython()

--- a/gui/widgets.py
+++ b/gui/widgets.py
@@ -3,9 +3,10 @@ from PySide6 import QtWidgets
 
 
 class VideoItemWidget(QtWidgets.QWidget):
-    """Placeholder widget representing a video entry."""
+    """Widget representing a single video entry."""
 
-    def __init__(self, parent=None):
+    def __init__(self, title: str, parent=None):
         super().__init__(parent)
         layout = QtWidgets.QHBoxLayout(self)
-        layout.addWidget(QtWidgets.QLabel("Video item"))
+        layout.addWidget(QtWidgets.QLabel(title))
+        # TODO: add thumbnail preview and play button using QMediaPlayer

--- a/main.py
+++ b/main.py
@@ -1,6 +1,19 @@
 """Entry point for the desktop application."""
 from PySide6 import QtWidgets
 
+
+def _graceful_shutdown(app: QtWidgets.QApplication, sched, observer) -> None:
+    """Connect clean-up handlers to the Qt application."""
+    def _on_quit():
+        if sched:
+            sched.shutdown(wait=False)
+        if observer:
+            observer.stop()
+            observer.join()
+
+    app.aboutToQuit.connect(_on_quit)
+
+
 from backend import db, models, watcher, scheduler
 from gui.main_window import MainWindow
 
@@ -25,15 +38,10 @@ def main() -> None:
     sched = scheduler.create_scheduler(session, settings.get("max_posts_per_day", 25))
 
     app = QtWidgets.QApplication([])
+    _graceful_shutdown(app, sched, observer)
     win = MainWindow(session, sched)
     win.show()
     app.exec()
-
-    if sched:
-        sched.shutdown(wait=False)
-    if observer:
-        observer.stop()
-        observer.join()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- flesh out the main window with a basic tree of videos
- add a dialog to choose a scheduled time
- connect graceful shutdown of scheduler and watcher to Qt
- prep for richer video widgets

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a2618cc708333953e31db673f156f