### PR TITLE
Expose metrics refresh interval in scheduler

### DIFF
--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -33,9 +33,24 @@ def post_due_videos(session: Session, max_posts_per_day: int):
             session.commit()
 
 
-def create_scheduler(session: Session, max_posts_per_day: int) -> BackgroundScheduler:
+def create_scheduler(
+    session: Session,
+    max_posts_per_day: int,
+    metrics_refresh_minutes: int = 30,
+) -> BackgroundScheduler:
+    """Create and start the background scheduler."""
     scheduler = BackgroundScheduler(daemon=True)
-    scheduler.add_job(post_due_videos, "interval", minutes=1, args=[session, max_posts_per_day])
-    scheduler.add_job(refresh_metrics, "interval", minutes=30, args=[session])
+    scheduler.add_job(
+        post_due_videos,
+        "interval",
+        minutes=1,
+        args=[session, max_posts_per_day],
+    )
+    scheduler.add_job(
+        refresh_metrics,
+        "interval",
+        minutes=metrics_refresh_minutes,
+        args=[session],
+    )
     scheduler.start()
     return scheduler

--- a/main.py
+++ b/main.py
@@ -35,7 +35,11 @@ def main() -> None:
     else:
         observer = None
 
-    sched = scheduler.create_scheduler(session, settings.get("max_posts_per_day", 25))
+    sched = scheduler.create_scheduler(
+        session,
+        settings.get("max_posts_per_day", 25),
+        settings.get("metrics_refresh_minutes", 30),
+    )
 
     app = QtWidgets.QApplication([])
     _graceful_shutdown(app, sched, observer)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -33,3 +33,12 @@ def test_post_due_videos(monkeypatch):
     assert len(posted) == 1
     assert v1.posted_at is not None
     assert v2.posted_at is None
+
+
+def test_create_scheduler_uses_refresh_interval():
+    session = create_session()
+    sched = scheduler.create_scheduler(session, 1, metrics_refresh_minutes=42)
+    # Find the refresh_metrics job
+    job = next(j for j in sched.get_jobs() if j.func == scheduler.refresh_metrics)
+    assert job.trigger.interval.total_seconds() == 42 * 60
+    sched.shutdown(wait=False)


### PR DESCRIPTION
## Summary
- make `create_scheduler` accept `metrics_refresh_minutes`
- pass new setting in `main.py`
- test configurable refresh interval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a303d327483338edec11922b34039