### PR TITLE
Add schedule grid dialog

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -81,11 +81,15 @@ class MainWindow(QtWidgets.QMainWindow):
         video = self._current_video()
         if not video:
             return
-        dlg = ScheduleDialog(video.scheduled_at, self)
+        dlg = ScheduleDialog(parent=self)
         if dlg.exec():
-            video.scheduled_at = dlg.scheduled_at
-            self.session.commit()
-            self.load_videos()
+            template = dlg.schedule_template
+            if template:
+                now = datetime.utcnow()
+                dt = datetime.combine(now.date(), template[0])
+                video.scheduled_at = dt
+                self.session.commit()
+                self.load_videos()
 
     def post_selected(self) -> None:
         video = self._current_video()

--- a/gui/schedule_dialog.py
+++ b/gui/schedule_dialog.py
@@ -1,25 +1,44 @@
-"""Dialog for setting a video's scheduled time."""
-from datetime import datetime
+"""Dialog for editing the daily posting schedule template."""
+from __future__ import annotations
+
+from datetime import time
+from typing import Iterable, List
 
 from PySide6 import QtCore, QtWidgets
 
 
 class ScheduleDialog(QtWidgets.QDialog):
-    """Simple datetime picker dialog."""
+    """Table-based editor for daily posting times."""
 
-    def __init__(self, scheduled_at: datetime | None, parent=None):
+    def __init__(self, template: Iterable[time] | None = None, parent=None):
         super().__init__(parent)
-        self.setWindowTitle("Schedule Video")
+        self.setWindowTitle("Schedule Template")
 
         layout = QtWidgets.QVBoxLayout(self)
 
-        self.dt = QtWidgets.QDateTimeEdit(self)
-        self.dt.setCalendarPopup(True)
-        if scheduled_at:
-            self.dt.setDateTime(QtCore.QDateTime.fromPython(scheduled_at))
-        else:
-            self.dt.setDateTime(QtCore.QDateTime.currentDateTime())
-        layout.addWidget(self.dt)
+        self.table = QtWidgets.QTableWidget(25, 2, self)
+        self.table.setHorizontalHeaderLabels(["Active", "Time"])
+        self.table.verticalHeader().setVisible(False)
+        self.table.horizontalHeader().setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeToContents)
+        self.table.horizontalHeader().setSectionResizeMode(1, QtWidgets.QHeaderView.Stretch)
+
+        for row in range(25):
+            chk = QtWidgets.QCheckBox()
+            self.table.setCellWidget(row, 0, chk)
+            t_edit = QtWidgets.QTimeEdit(QtCore.QTime(8, 0))
+            t_edit.setDisplayFormat("HH:mm")
+            self.table.setCellWidget(row, 1, t_edit)
+
+        if template:
+            for row, t in enumerate(template):
+                if row >= 25:
+                    break
+                chk = self.table.cellWidget(row, 0)
+                t_edit = self.table.cellWidget(row, 1)
+                chk.setChecked(True)
+                t_edit.setTime(QtCore.QTime(t.hour, t.minute))
+
+        layout.addWidget(self.table)
 
         buttons = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel,
@@ -29,6 +48,16 @@ class ScheduleDialog(QtWidgets.QDialog):
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
 
+    # ------------------------------------------------------------------
     @property
-    def scheduled_at(self) -> datetime:
-        return self.dt.dateTime().toPython()
+    def schedule_template(self) -> List[time]:
+        """Return checked times sorted ascending."""
+        times: List[time] = []
+        for row in range(self.table.rowCount()):
+            chk = self.table.cellWidget(row, 0)
+            t_edit = self.table.cellWidget(row, 1)
+            if isinstance(chk, QtWidgets.QCheckBox) and chk.isChecked():
+                qtime = t_edit.time() if isinstance(t_edit, QtWidgets.QTimeEdit) else QtCore.QTime(0, 0)
+                times.append(qtime.toPython())
+        times.sort()
+        return times

--- a/tests/test_schedule_dialog.py
+++ b/tests/test_schedule_dialog.py
@@ -1,0 +1,22 @@
+from datetime import time
+import os
+
+import pytest
+
+try:
+    from PySide6 import QtWidgets
+    from gui.schedule_dialog import ScheduleDialog
+except Exception:  # pragma: no cover - missing Qt deps
+    QtWidgets = None
+    ScheduleDialog = None
+
+
+@pytest.mark.skipif(ScheduleDialog is None, reason="PySide6 not available")
+def test_schedule_dialog_returns_template():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+    template = [time(8, 0), time(12, 30)]
+    dlg = ScheduleDialog(template)
+    assert dlg.schedule_template == template
+


### PR DESCRIPTION
## Summary
- redesign `ScheduleDialog` as a table-based schedule editor
- adapt `MainWindow.schedule_selected` to use the new dialog
- add unit test for the schedule grid dialog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a303fb4508333aad644f633cd6662