### PR TITLE
Add scheduler update utilities and config dialog

### DIFF
--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -1,6 +1,7 @@
 """Background scheduler configuration."""
 from datetime import datetime, date
 from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.interval import IntervalTrigger
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 
@@ -35,7 +36,38 @@ def post_due_videos(session: Session, max_posts_per_day: int):
 
 def create_scheduler(session: Session, max_posts_per_day: int) -> BackgroundScheduler:
     scheduler = BackgroundScheduler(daemon=True)
-    scheduler.add_job(post_due_videos, "interval", minutes=1, args=[session, max_posts_per_day])
-    scheduler.add_job(refresh_metrics, "interval", minutes=30, args=[session])
+    scheduler.add_job(
+        post_due_videos,
+        "interval",
+        minutes=1,
+        args=[session, max_posts_per_day],
+        id="post_due_videos",
+    )
+    scheduler.add_job(
+        refresh_metrics,
+        "interval",
+        minutes=30,
+        args=[session],
+        id="refresh_metrics",
+    )
     scheduler.start()
     return scheduler
+
+
+def update_post_job(scheduler: BackgroundScheduler, max_posts_per_day: int) -> None:
+    """Modify the post job arguments when settings change."""
+    job = scheduler.get_job("post_due_videos")
+    if job:
+        args = list(job.args)
+        if len(args) >= 2:
+            args[1] = max_posts_per_day
+        else:
+            args.append(max_posts_per_day)
+        scheduler.modify_job(job.id, args=args)
+
+
+def update_metrics_job(scheduler: BackgroundScheduler, minutes: int) -> None:
+    """Reschedule the metrics refresh job with a new interval."""
+    job = scheduler.get_job("refresh_metrics")
+    if job:
+        scheduler.reschedule_job(job.id, trigger=IntervalTrigger(minutes=minutes))

--- a/gui/config_dialog.py
+++ b/gui/config_dialog.py
@@ -1,0 +1,36 @@
+from PySide6 import QtWidgets
+
+
+class ConfigDialog(QtWidgets.QDialog):
+    """Small dialog for modifying application settings."""
+
+    def __init__(self, settings: dict, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Settings")
+
+        layout = QtWidgets.QFormLayout(self)
+
+        self.spin_max_posts = QtWidgets.QSpinBox()
+        self.spin_max_posts.setRange(0, 25)
+        self.spin_max_posts.setValue(settings.get("max_posts_per_day", 25))
+        layout.addRow("Max posts / day", self.spin_max_posts)
+
+        self.spin_metrics = QtWidgets.QSpinBox()
+        self.spin_metrics.setRange(5, 120)
+        self.spin_metrics.setValue(settings.get("metrics_refresh_minutes", 30))
+        layout.addRow("Metrics refresh (min)", self.spin_metrics)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel,
+            parent=self,
+        )
+        layout.addRow(buttons)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+
+    # --------------------------------------------------------------
+    def values(self) -> dict:
+        return {
+            "max_posts_per_day": self.spin_max_posts.value(),
+            "metrics_refresh_minutes": self.spin_metrics.value(),
+        }

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -6,7 +6,9 @@ from PySide6 import QtCore, QtWidgets
 
 from backend.models import Video
 from backend.instagram import post_to_instagram
+from backend import scheduler as sched_utils
 from .schedule_dialog import ScheduleDialog
+from .config_dialog import ConfigDialog
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -32,14 +34,17 @@ class MainWindow(QtWidgets.QMainWindow):
         self.btn_refresh = QtWidgets.QPushButton("Refresh")
         self.btn_schedule = QtWidgets.QPushButton("Schedule")
         self.btn_post_now = QtWidgets.QPushButton("Post Now")
+        self.btn_settings = QtWidgets.QPushButton("Settings")
         btn_layout.addWidget(self.btn_refresh)
         btn_layout.addWidget(self.btn_schedule)
         btn_layout.addWidget(self.btn_post_now)
+        btn_layout.addWidget(self.btn_settings)
         layout.addLayout(btn_layout)
 
         self.btn_refresh.clicked.connect(self.load_videos)
         self.btn_schedule.clicked.connect(self.schedule_selected)
         self.btn_post_now.clicked.connect(self.post_selected)
+        self.btn_settings.clicked.connect(self.open_config)
 
         self.load_videos()
 
@@ -100,4 +105,17 @@ class MainWindow(QtWidgets.QMainWindow):
             self.session.commit()
             QtWidgets.QMessageBox.warning(self, "Error", str(exc))
         self.load_videos()
+
+    def open_config(self) -> None:
+        dlg = ConfigDialog(self.session.settings, self)
+        if dlg.exec():
+            new_vals = dlg.values()
+            self.session.settings.update(new_vals)
+            with open("settings.json", "w") as f:
+                import json
+                json.dump(self.session.settings, f, indent=4)
+            sched_utils.update_post_job(self.scheduler, new_vals["max_posts_per_day"])
+            sched_utils.update_metrics_job(
+                self.scheduler, new_vals["metrics_refresh_minutes"]
+            )
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -33,3 +33,19 @@ def test_post_due_videos(monkeypatch):
     assert len(posted) == 1
     assert v1.posted_at is not None
     assert v2.posted_at is None
+
+
+def test_update_jobs():
+    session = create_session()
+    sched = scheduler.create_scheduler(session, max_posts_per_day=5)
+    # update post job
+    scheduler.update_post_job(sched, 10)
+    post_job = sched.get_job("post_due_videos")
+    assert post_job.args[1] == 10
+
+    # update metrics interval
+    scheduler.update_metrics_job(sched, 15)
+    metrics_job = sched.get_job("refresh_metrics")
+    assert metrics_job.trigger.interval.seconds == 15 * 60
+
+    sched.shutdown()


### PR DESCRIPTION
## Summary
- allow updating scheduler jobs with `update_post_job` and `update_metrics_job`
- add a simple config dialog
- integrate settings dialog into main window
- test job update helpers

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a30422a7883338daaf6149fb21c1b