### PR TITLE
Implement HTTP server for Instagram uploads

### DIFF
--- a/backend/instagram.py
+++ b/backend/instagram.py
@@ -1,10 +1,70 @@
 """Minimal Instagram Graph API helper."""
+from __future__ import annotations
+
+import functools
+import hashlib
+import http.server
+import shutil
+import socketserver
+import tempfile
+import threading
 import time
-import requests
+from pathlib import Path
+
 import keyring
+import requests
+
 from .models import Video
 
 API = "https://graph.facebook.com/v21.0"
+
+# ---------------------------------------------------------------------------
+# Local HTTP server to expose files to the Instagram API
+# ---------------------------------------------------------------------------
+SERVE_DIR = Path(tempfile.gettempdir()) / "ig_uploads"
+_SERVER: socketserver.TCPServer | None = None
+_THREAD: threading.Thread | None = None
+_PORT: int | None = None
+
+
+def start_http_server(port: int = 0) -> int:
+    """Start a background HTTP server serving ``SERVE_DIR``."""
+    global _SERVER, _THREAD, _PORT
+    if _SERVER:
+        return _PORT or 0
+
+    SERVE_DIR.mkdir(parents=True, exist_ok=True)
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=str(SERVE_DIR))
+    _SERVER = socketserver.TCPServer(("127.0.0.1", port), handler)
+    _PORT = _SERVER.server_address[1]
+    _THREAD = threading.Thread(target=_SERVER.serve_forever, daemon=True)
+    _THREAD.start()
+    return _PORT
+
+
+def stop_http_server() -> None:
+    """Stop the background HTTP server if running."""
+    global _SERVER, _THREAD, _PORT
+    if _SERVER:
+        _SERVER.shutdown()
+        _SERVER.server_close()
+        _SERVER = None
+        _THREAD = None
+        _PORT = None
+
+
+def _local_http_url(file_path: str) -> str:
+    """Copy ``file_path`` to ``SERVE_DIR`` and return an accessible URL."""
+    port = start_http_server()
+
+    src = Path(file_path)
+    with src.open("rb") as f:
+        sha = hashlib.sha256(f.read()).hexdigest()
+    dest = SERVE_DIR / f"{sha}{src.suffix}"
+    if not dest.exists():
+        shutil.copy2(src, dest)
+
+    return f"http://127.0.0.1:{port}/{dest.name}"
 
 
 def post_to_instagram(session, video):
@@ -16,7 +76,7 @@ def post_to_instagram(session, video):
     r = requests.post(
         f"{API}/{user_id}/media",
         data={
-            "video_url": video.file_path,
+            "video_url": _local_http_url(video.file_path),
             "caption": f"{video.title}\n\n{video.description}",
             "published": "false",
         },

--- a/main.py
+++ b/main.py
@@ -10,11 +10,13 @@ def _graceful_shutdown(app: QtWidgets.QApplication, sched, observer) -> None:
         if observer:
             observer.stop()
             observer.join()
+        stop_http_server()
 
     app.aboutToQuit.connect(_on_quit)
 
 
 from backend import db, models, watcher, scheduler
+from backend.instagram import stop_http_server
 from gui.main_window import MainWindow
 
 

--- a/tests/test_instagram.py
+++ b/tests/test_instagram.py
@@ -1,0 +1,14 @@
+import urllib.request
+from backend import instagram
+
+
+def test_local_http_url(tmp_path):
+    file_path = tmp_path / "vid.mp4"
+    data = b"hello"
+    file_path.write_bytes(data)
+
+    url = instagram._local_http_url(str(file_path))
+    with urllib.request.urlopen(url) as resp:
+        assert resp.read() == data
+
+    instagram.stop_http_server()


### PR DESCRIPTION
## Summary
- add a lightweight HTTP server and `_local_http_url` to expose videos
- stop the HTTP server when the app exits
- test the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a30457670833386c7aaab70f75a96