### PR TITLE
Improve test suite and CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
+          pip install pytest pytest-cov
       - name: Run tests
-        run: pytest -v
+        run: pytest --cov=./ --cov-report=term-missing -v

--- a/tests/test_instagram.py
+++ b/tests/test_instagram.py
@@ -12,3 +12,74 @@ def test_local_http_url(tmp_path):
         assert resp.read() == data
 
     instagram.stop_http_server()
+
+import json
+from types import SimpleNamespace
+
+from backend.models import Base, Video
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+def create_session():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_post_to_instagram(monkeypatch):
+    session = create_session()
+    vid = Video(file_path="a.mp4", sha256="x")
+    session.add(vid)
+    session.commit()
+    session.settings = {"instagram_user_id": "1"}
+
+    # Fake credentials
+    monkeypatch.setattr(instagram.keyring, "get_password", lambda *a, **k: "token")
+
+    def fake_local(url):
+        return "http://local/file.mp4"
+
+    monkeypatch.setattr(instagram, "_local_http_url", fake_local)
+
+    posts = []
+    gets = []
+
+    def fake_post(url, data=None, params=None, timeout=None):
+        posts.append((url, data, params))
+        if "media_publish" in url:
+            return SimpleNamespace(json=lambda: {"id": "media123"}, raise_for_status=lambda: None)
+        else:
+            return SimpleNamespace(json=lambda: {"id": "container1"}, raise_for_status=lambda: None)
+
+    def fake_get(url, params=None):
+        gets.append((url, params))
+        return SimpleNamespace(json=lambda: {"status_code": "FINISHED"})
+
+    monkeypatch.setattr(instagram.requests, "post", fake_post)
+    monkeypatch.setattr(instagram.requests, "get", fake_get)
+    monkeypatch.setattr(instagram.time, "sleep", lambda s: None)
+
+    instagram.post_to_instagram(session, vid)
+    assert vid.insta_media_id == "media123"
+    assert any("media_publish" in c[0] for c in posts)
+
+
+def test_refresh_metrics(monkeypatch):
+    session = create_session()
+    vid = Video(file_path="a.mp4", sha256="x", insta_media_id="123")
+    session.add(vid)
+    session.commit()
+    session.settings = {"instagram_user_id": "1"}
+
+    monkeypatch.setattr(instagram.keyring, "get_password", lambda *a, **k: "token")
+
+    def fake_get(url, params=None):
+        return SimpleNamespace(json=lambda: {"like_count": 1, "comments_count": 2, "video_view_count": 3})
+
+    monkeypatch.setattr(instagram.requests, "get", fake_get)
+
+    instagram.refresh_metrics(session)
+    updated = session.get(Video, vid.id)
+    assert updated.likes == 1 and updated.comments == 2 and updated.views == 3

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1,0 +1,41 @@
+import os
+import pytest
+
+try:
+    from PySide6 import QtWidgets
+    from gui.main_window import MainWindow
+    from backend.models import Base, Video
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+except Exception:  # pragma: no cover - missing Qt deps
+    QtWidgets = None
+
+
+def create_session():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+@pytest.mark.skipif(QtWidgets is None, reason="PySide6 not available")
+def test_main_window_load_and_delete(monkeypatch, tmp_path):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+    session = create_session()
+    video = Video(file_path=str(tmp_path / "a.mp4"), sha256="x", title="Vid")
+    session.add(video)
+    session.commit()
+
+    monkeypatch.setattr('send2trash.send2trash', lambda p: None)
+
+    win = MainWindow(session, scheduler=None)
+    win.load_videos()
+    assert win.tree.topLevelItemCount() == 1
+
+    item = win.tree.topLevelItem(0)
+    win.tree.setCurrentItem(item)
+    win.delete_selected()
+
+    assert session.get(Video, video.id).is_active is False

--- a/tests/test_watcher_start.py
+++ b/tests/test_watcher_start.py
@@ -1,0 +1,36 @@
+from backend import watcher
+from backend.models import Base
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+def create_session():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+class DummyObserver:
+    def __init__(self):
+        self.scheduled = []
+        self.daemon = False
+        self.started = False
+
+    def schedule(self, handler, path, recursive=False):
+        self.scheduled.append((handler, path, recursive))
+
+    def start(self):
+        self.started = True
+
+
+def test_start_watcher_monkeypatch(monkeypatch, tmp_path):
+    session = create_session()
+    dummy = DummyObserver()
+    monkeypatch.setattr(watcher, "Observer", lambda: dummy)
+
+    obs = watcher.start_watcher(str(tmp_path), session)
+    assert obs is dummy
+    assert dummy.started
+    assert dummy.daemon
+    assert dummy.scheduled[0][1] == str(tmp_path)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,0 +1,27 @@
+import pytest
+
+try:
+    from PySide6 import QtGui
+    from gui.widgets import _generate_thumbnail
+    import ffmpeg
+except Exception:  # pragma: no cover - missing Qt deps
+    QtGui = None
+
+
+@pytest.mark.skipif(QtGui is None, reason="PySide6 not available")
+def test_generate_thumbnail_handles_error(monkeypatch, tmp_path):
+    dummy = tmp_path / "vid.mp4"
+    dummy.write_text("data")
+
+    class Dummy:
+        def output(self, *a, **k):
+            return self
+        def overwrite_output(self):
+            return self
+        def run(self, quiet=True):
+            raise RuntimeError
+
+    monkeypatch.setattr(ffmpeg, "input", lambda *a, **k: Dummy())
+
+    pixmap = _generate_thumbnail(str(dummy))
+    assert isinstance(pixmap, QtGui.QPixmap)


### PR DESCRIPTION
## Summary
- add CI coverage reporting via pytest-cov
- create test for main window deletion logic
- exercise instagram posting and metrics with mocks
- ensure watcher startup is tested
- check thumbnail generation error handling

## Testing
- `pytest -q`
- `pytest --cov=./ --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_b_684a32e25c2c8333b8f8e4c4fca5998a